### PR TITLE
Feat/cilium ingress

### DIFF
--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -57,3 +57,32 @@ Maybe in the future? Who knows...
 ```bash
 helm uninstall cilium -n cilium
 ```
+
+## Upgrading/Updating 
+
+After upgrading or updating Cilium, it is recommended to restart all deployments and daemonsets in order to apply the new configs:
+
+```bash
+kubectl -n cilium rollout restart deployment/cilium-operator
+
+kubectl -n cilium rollout restart ds/cilium
+```
+
+## Ingress setup
+
+Cilium has an Ingress implementation uses the original Kubernetes Ingress resource, with extra functionalities and complexity.
+
+To enable and use the Cilium Ingress as the default IngressClass, it is necessary to configure the following values in the [/helm/cilium/values.yaml](/helm/cilium/values.yaml) file:
+
+```yaml
+...
+ingressController:
+   enabled: true
+   default: true
+   loadbalancerMode: shared
+...
+```
+
+These values enable Cilium Ingress. A unique `LoadBalancer` type service is created in order to redirect incoming traffic to the desired service.
+
+This approach is simpler and easier. For more complex and bigger setups, it is recommended to use the ``ingressController.loadbalancerMode=dedicated`. For more information check the official [docs](https://docs.cilium.io/en/stable/network/servicemesh/ingress/).

--- a/helm/cilium/README.md
+++ b/helm/cilium/README.md
@@ -86,3 +86,11 @@ ingressController:
 These values enable Cilium Ingress. A unique `LoadBalancer` type service is created in order to redirect incoming traffic to the desired service.
 
 This approach is simpler and easier. For more complex and bigger setups, it is recommended to use the ``ingressController.loadbalancerMode=dedicated`. For more information check the official [docs](https://docs.cilium.io/en/stable/network/servicemesh/ingress/).
+
+### Available Ingresses
+
+All DNS names were defined locally on `/etc/hosts` file.
+
+| Service |          DNS          |
+| :-----: | :-------------------: |
+| Grafana | grafana.playground.io |

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -898,7 +898,7 @@ envoyConfig:
 ingressController:
   # -- Enable cilium ingress controller
   # This will automatically set enable-envoy-config as well.
-  enabled: false
+  enabled: true
   # -- Set cilium ingress controller to be the default ingress controller
   # This will let cilium ingress controller route entries without ingress class set
   default: false
@@ -2254,7 +2254,7 @@ loadBalancer:
     # Applicable values:
     #   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.
     #   - disabled: Disable L7 load balancing by way of service annotation.
-    backend: disabled
+    backend: envoy
     # -- List of ports from service to be automatically redirected to above backend.
     # Any service exposing one of these ports will be automatically redirected.
     # Fine-grained control can be achieved by using the service annotation.

--- a/helm/cilium/values.yaml
+++ b/helm/cilium/values.yaml
@@ -901,12 +901,12 @@ ingressController:
   enabled: true
   # -- Set cilium ingress controller to be the default ingress controller
   # This will let cilium ingress controller route entries without ingress class set
-  default: false
+  default: true
   # -- Default ingress load balancer mode
   # Supported values: shared, dedicated
   # For granular control, use the following annotations on the ingress resource:
   # "ingress.cilium.io/loadbalancer-mode: dedicated" (or "shared").
-  loadbalancerMode: dedicated
+  loadbalancerMode: shared
   # -- Enforce https for host having matching TLS host in Ingress.
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
@@ -2267,9 +2267,9 @@ loadBalancer:
 # -- Configure N-S k8s service loadbalancing
 nodePort:
   # -- Enable the Cilium NodePort service implementation.
-  enabled: false
+  enabled: true
   # -- Port range to use for NodePort services.
-  # range: "30000,32767"
+  range: "30000,32767"
 
   # @schema
   # type: [null, string, array]

--- a/manifests/argocd-ingress.yaml
+++ b/manifests/argocd-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-ingress
+  namespace: argocd
+
+spec:
+  ingressClassName: cilium
+  rules:
+    - host: "argo.playground.io"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  name: http  # same port name configured on the argocd-server service

--- a/manifests/grafana-ingress.yaml
+++ b/manifests/grafana-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: lgtm
+
+spec:
+  ingressClassName: cilium
+  rules:
+    - host: "grafana.playground.io"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lgtm-grafana
+                port:
+                  number: 80


### PR DESCRIPTION
Enabled Cilium Ingress support.

Ingress was configured in "shared" mode, which essentially mean, one `loadBalancer` type service will handle all incoming traffic from Ingress and direct it into the desired service.

A simpler approach, although it might complicate serving apps in case multiple services have a sub-domain instead of their own domain.

i.e. (this is not real, just to provide an idea):
argo and grafana are both using `playground.io` and both also use the sub-path `/home`